### PR TITLE
Changed permission for snapraid-runner.conf and added flag for cronjob

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 
 snapraid_install: true
 snapraid_runner: true
+snapraid_runner_cronjob: true
 
 snapraid_apt_package_name: snapraid
 snapraid_bin_path: /usr/local/bin/snapraid

--- a/tasks/snapraid-runner.yml
+++ b/tasks/snapraid-runner.yml
@@ -11,9 +11,10 @@
     dest: "{{ snapraid_runner_conf }}"
     owner: root
     group: root
-    mode: 0775
+    mode: 0770
 
 - name: setup cron job snapraid-runner
+  when: snapraid_runner_cronjob
   cron:
     user: "root"
     job: "{{ item.job }}"


### PR DESCRIPTION
https://github.com/ironicbadger/ansible-role-snapraid/pull/17
> Currently the snapraid-runner.conf file is created with permission 775 thus making it world readable. This file may contain SMTP credentials which, if leaked, could grant access to the associated mail.
> 
> I also added a new variable for allowing to skip the cronjob. In my workflow i run snapraid after all my other backup tasks have executed and thus it is executed inside another cronjob.