### PR TITLE
Adding support for installing from Package Manager

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,11 @@
 snapraid_install: true
 snapraid_runner: true
 
+# Install mode: defines where to download and install the package from
+# - "from_source" will use the docker based source build process
+# - "package_manager" will install from the linux distrubution package manager
+snapraid_install_mode: from_source
+
 snapraid_apt_package_name: snapraid
 snapraid_bin_path: /usr/local/bin/snapraid
 snapraid_force_install: false

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -14,27 +14,27 @@
   apt:
     name: "{{ snapraid_apt_package_name }}"
     state: present
-  when: (install_snapraid) and (snapraid_install_mode == package_manager)
+  when: install_snapraid and snapraid_install_mode == "package_manager"
 
 - name: build snapraid | clone git repo
   git:
     repo: https://github.com/IronicBadger/docker-snapraid.git
     dest: /tmp/snapraid
     force: yes
-  when: install_snapraid and (snapraid_install_mode == from_source)
+  when: install_snapraid and snapraid_install_mode == "from_source"
 
 - name: build snapraid | make build script executable
   file:
     path: /tmp/snapraid/build.sh
     mode: 0775
-  when: install_snapraid and (snapraid_install_mode == from_source)
+  when: install_snapraid and snapraid_install_mode == "from_source"
 
 - name: build snapraid | build .deb package
   shell: cd /tmp/snapraid && ./build.sh
-  when: install_snapraid and (snapraid_install_mode == from_source)
+  when: install_snapraid and snapraid_install_mode == "from_source"
 
 - name: build snapraid | install built .deb
   apt:
     deb: /tmp/snapraid/build/snapraid-from-source.deb
     state: present
-  when: install_snapraid and (snapraid_install_mode == from_source)
+  when: install_snapraid and snapraid_install_mode == "from_source"

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -10,25 +10,31 @@
   set_fact:
     install_snapraid: "{{ snapraid_force_install == true or is_installed.failed == true }}"
 
+- name: install snapraid from package manager
+  apt:
+    name: "{{ snapraid_apt_package_name }}"
+    state: present
+  when: (install_snapraid) and (snapraid_install_mode == package_manager)
+
 - name: build snapraid | clone git repo
   git:
     repo: https://github.com/IronicBadger/docker-snapraid.git
     dest: /tmp/snapraid
     force: yes
-  when: install_snapraid
+  when: install_snapraid and (snapraid_install_mode == from_source)
 
 - name: build snapraid | make build script executable
   file:
     path: /tmp/snapraid/build.sh
     mode: 0775
-  when: install_snapraid
+  when: install_snapraid and (snapraid_install_mode == from_source)
 
 - name: build snapraid | build .deb package
   shell: cd /tmp/snapraid && ./build.sh
-  when: install_snapraid
+  when: install_snapraid and (snapraid_install_mode == from_source)
 
 - name: build snapraid | install built .deb
   apt:
     deb: /tmp/snapraid/build/snapraid-from-source.deb
     state: present
-  when: install_snapraid
+  when: install_snapraid and (snapraid_install_mode == from_source)


### PR DESCRIPTION
https://github.com/ironicbadger/ansible-role-snapraid/pull/15

> This will allow someone to use the Debian/Ubuntu distribution package instead of building from source.
>
> The variable still defaults to building from source via the Docker option, and can be overridden by changing the variable to "package_manager"
