### PR TITLE
Add support for TLS in SMPT connection

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,7 @@ snapraid_runner_email_sendon: "error"
 snapraid_runner_smtp_host: smtp.gmail.com
 snapraid_runner_smtp_port: 465
 snapraid_runner_use_ssl: true
+snapraid_runner_use_tls: false
 
 snapraid_content_files:
   - /var/snapraid.content

--- a/templates/snapraid-runner.conf.j2
+++ b/templates/snapraid-runner.conf.j2
@@ -29,6 +29,7 @@ host = {{ snapraid_runner_smtp_host }}
 port = {{ snapraid_runner_smtp_port }}
 ; set to "true" to activate
 ssl = {{ snapraid_runner_use_ssl }}
+tls = {{ snapraid_runner_use_tls }}
 user = {{ snapraid_runner_email_address }}
 password = {{ snapraid_runner_email_pass }}
 


### PR DESCRIPTION
https://github.com/ironicbadger/ansible-role-snapraid/pull/13

> Snapraid-runner has had support for TLS in it's SMTP configuration since [v0.4](https://github.com/Chronial/snapraid-runner#v04-17-aug-2019). This commit adds that support to your Ansible role, without changing any defaults